### PR TITLE
Adding functionality for view to be a path to json file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,31 @@
 var es = require('event-stream');
 var gutil = require('gulp-util');
 var mustache = require('mustache');
+var fs = require('fs');
 
 module.exports = function (view, options) {
     options = options || {};
     options.extension = options.extension || '.html';
+    var err = null;
 
-    return es.map(function (file, cb) {
-        file.contents = new Buffer(mustache.render(file.contents.toString(), view));
-        file.path = gutil.replaceExtension(file.path, options.extension);
-        cb(null, file);
-    });
-};
+    //If view is string, interpret as path to json filename
+    if (typeof view === "string") {
+	try {
+	    view = JSON.parse(fs.readFileSync(view,'utf8'));
+	} catch (e) {
+	    err = e;
+	}
+    }
+
+    function renderFile(file) {
+	if (err) {
+	    return this.emit('error', new Error(err.message));
+	} else {
+            file.contents = new Buffer(mustache.render(file.contents.toString(), view));
+            file.path = gutil.replaceExtension(file.path, options.extension);
+	    return this.emit('data',file);
+	}
+
+    }
+    return es.through(renderFile);
+}

--- a/test/fixtures/nok.json
+++ b/test/fixtures/nok.json
@@ -1,0 +1,3 @@
+{
+  "title": "gulp-mustache"lolwut
+}

--- a/test/fixtures/ok.json
+++ b/test/fixtures/ok.json
@@ -1,0 +1,3 @@
+{
+  "title": "gulp-mustache"
+}

--- a/test/main.js
+++ b/test/main.js
@@ -77,6 +77,53 @@ describe('gulp-mustache', function () {
         stream.end();
     });
 
+    it('should produce correct html output using json file', function (done) {
+        var srcFile = new gutil.File({
+            path: 'test/fixtures/ok.mustache',
+            cwd: 'test/',
+            base: 'test/fixtures',
+            contents: fs.readFileSync('test/fixtures/ok.mustache')
+        });
+
+        var stream = mustache('test/fixtures/ok.json');
+
+        stream.on('error', function (err) {
+            should.exist(err);
+            done(err);
+        });
+
+        stream.on('data', function (newFile) {
+
+            should.exist(newFile);
+            should.exist(newFile.contents);
+
+            String(newFile.contents).should.equal(String(expectedFile.contents));
+            done();
+        });
+
+        stream.write(srcFile);
+        stream.end();
+    });
+
+    it('should detect malformed json and emit error', function (done) {
+        var srcFile = new gutil.File({
+            path: 'test/fixtures/ok.mustache',
+            cwd: 'test/',
+            base: 'test/fixtures',
+            contents: fs.readFileSync('test/fixtures/ok.mustache')
+        });
+
+        var stream = mustache('test/fixtures/nok.json');
+
+        stream.on('error', function (err) {
+            should.exist(err);
+            done();
+        });
+
+	stream.write(srcFile);
+        stream.end();
+    });
+
     // it('should throw error when syntax is incorrect', function (done) {
 
     //     var srcFile = new gutil.File({


### PR DESCRIPTION
Up to you whether or not you want to merge this in. For a project I'm working on, I require taking a view context in from a file. Instead of requiring the fs module and doing it within the gulpfile, I decided to take your plugin and add the functionality. 

I also switched invocation to use es.through because it is not possible to emit error events from es.map. I added 2 tests: 1 using a correct json file and 1 using a malformed json file. The tests confirm that error events are thrown when reading malformed json from the file.
