### PR TITLE
Remove the default file extension -> .html clobber

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ The view object, containing all template variables as keys. If you pass a `strin
 
 #### options
 Type: `hash`
-Default: `{ extension: '.html' }`
+Default: `{ }`
 
 The options object to configure the plugin.
 
 ##### options.extension
 Type: `string`
-Default: `.html`
+Default: the extension of the current file
 
 #### partials
 Type: `hash`
-Default: `{}`
+Default: `{ }`
 
 An optional object of mustache partial strings. See [mustache.js](https://github.com/janl/mustache.js/) for details on partials in mustache.
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var fs = require('fs');
 
 module.exports = function (view, options, partials) {
     options = options || {};
-    options.extension = options.extension || '.html';
     partials = partials || {};
 
     var viewError = null;
@@ -42,7 +41,9 @@ module.exports = function (view, options, partials) {
         }
 
         file.contents = new Buffer(mustache.render(file.contents.toString(), view, partials));
-        file.path = gutil.replaceExtension(file.path, options.extension);
+        if (typeof options.extension === 'string') {
+            file.path = gutil.replaceExtension(file.path, options.extension);
+        }
         this.push(file);
         cb();
     });


### PR DESCRIPTION
This makes it impossible to use gulp-mustache with multiple file
extensions, because there is no way to retrieve the current file
extension. This task is better handled by plugins like
gulp-rename, and the default for gulp-mustache should allow general
use of the template engine.

Related: #3
