### PR TITLE
Add ability to use different view object per file

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function (view, options, partials) {
             );
         }
 
-        file.contents = new Buffer(mustache.render(file.contents.toString(), view, partials));
+        file.contents = new Buffer(mustache.render(file.contents.toString(), file.data || view, partials));
         if (typeof options.extension === 'string') {
             file.path = gutil.replaceExtension(file.path, options.extension);
         }


### PR DESCRIPTION
A very simple change based on [gulp-data](https://github.com/colynb/gulp-data#note-to-gulp-plugin-authors). Allows developers to render mustache templates with different view data on a file-bases.
