### PR TITLE
Support recursive loading of missing partials from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ gulp.src("./templates/*.mustache")
 	})).pipe(gulp.dest("./dist"));
 ```
 
+## Partials loaded from disk
+
+[Mustache partials](https://mustache.github.io/mustache.5.html#Partials) not given in the `partials` argument will be loaded from disk, relative from the file currently being processed:
+
+```
+{{> ../partials/head }}
+```
+
+This will find a `head.mustache` in the partials directory next to the current file's directory. Partials loading is recursive.
+
 ## API
 
 ### mustache(view, options, partials)


### PR DESCRIPTION
Support recursive loading of missing partials from disk, using relative paths from the current file.

I had a need for this feature at work, for building hierarchies of partials etc.

It kicks in as a fallback if the partials array does not have the entry and then loads it from disk and puts it into partials.