### PR TITLE
fixed #17: strip utf-8 bom and handle file extension.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,9 +72,8 @@ module.exports = function (view, options, partials) {
 
             if (!partials[partialName]) {
                 try {
-                    var suffix = (options.extension || '.mustache');
-                        suffix = (suffix.charAt(0) == "." ? suffix : "." + suffix);
-                    var partialPath = path.resolve(templateDir, partialName + suffix);
+                    var extension = (typeof options.extension == "string" ? (options.extension || ".mustache") : "");
+                    var partialPath = path.resolve(templateDir, partialName + extension);
                     var partial = stripbom(fs.readFileSync(partialPath, 'utf8'));
                     partials[partialName] = partial;
                     loadPartials.call(this, partial, partialPath);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var gutil = require('gulp-util');
 var mustache = require('mustache');
 var fs = require('fs');
 var path = require('path');
+var stripbom = require("strip-bom");
 
 module.exports = function (view, options, partials) {
     options = options || {};
@@ -43,7 +44,7 @@ module.exports = function (view, options, partials) {
 
         var template = file.contents.toString();
         try {
-            loadPartials(template, file.path);
+            loadPartials.call(this, template, file.path);
         } catch (e) {
             this.emit(
                 'error',
@@ -71,10 +72,12 @@ module.exports = function (view, options, partials) {
 
             if (!partials[partialName]) {
                 try {
-                    var partialPath = path.resolve(templateDir, partialName + '.mustache');
-                    var partial = fs.readFileSync(partialPath, 'utf8');
+                    var suffix = (options.extension || '.mustache');
+                        suffix = (suffix.charAt(0) == "." ? suffix : "." + suffix);
+                    var partialPath = path.resolve(templateDir, partialName + suffix);
+                    var partial = stripbom(fs.readFileSync(partialPath, 'utf8'));
                     partials[partialName] = partial;
-                    loadPartials(partial, partialPath);
+                    loadPartials.call(this, partial, partialPath);
                 } catch (ex) {
                      this.emit(
                         'error',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "gulp-util": "3.0.7",
     "mustache": "2.2.0",
-    "through2": "2.0.0"
+    "through2": "2.0.0",
+    "strip-bom": "2.0.0"
   },
   "devDependencies": {
     "mocha": "2.3.4",


### PR DESCRIPTION
1, strip utf-8 bom when using `{{>./part`}}
2, support custom partials file extension(also support without file extension.