### PR TITLE
fixed #17: just for the partials extension issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,8 @@ module.exports = function (view, options, partials) {
                             // or check if `partial + options.extension` is exists.
                             // e.g. 
                             //   if `options.extension` equals ".html": 
-                            //   `{{> ./path/to/partial }}` => `{{> ./path/to/partial.html }}`
+                            //   the `{{> ./path/to/partial }}` will load 
+                            //   `./path/to/partial.html`.
                             if ( typeof options.extension == "string" ) {
                                 partialPath = path.resolve(
                                     templateDir, 
@@ -114,7 +115,11 @@ module.exports = function (view, options, partials) {
                             // `partialName + options.extension` does not exists. 
                             // try use `.mustache` extension to load `partial` file.
                             if ( partial === null ) {
-                                partialPath = path.resolve(templateDir, partialName + ".mustache");
+                                partialPath = path.resolve(
+                                    templateDir, 
+                                    partialName + ".mustache"
+                                );
+
                                 partial = fs.readFileSync(partialPath, 'utf8');
                             }
                         }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ module.exports = function (view, options, partials) {
                         else {
                             // or check if `partial + options.extension` is exists.
                             // e.g. 
-                            //   if `options.extension` equals ".html": `{{> ./path/to/partial }}` => `{{> ./path/to/partial.html }}`
+                            //   if `options.extension` equals ".html": 
+                            //   `{{> ./path/to/partial }}` => `{{> ./path/to/partial.html }}`
                             if ( typeof options.extension == "string" ) {
                                 partialPath = path.resolve(templateDir, partialName + options.extension);
                                 
@@ -106,8 +107,9 @@ module.exports = function (view, options, partials) {
                                 }
                             }
 
-                            // when `options.extension` is not a string or `partialName + options.extension`
-                            // does not exists. try use `.mustache` extension to load `partial` file.
+                            // when `options.extension` is not a string or 
+                            // `partialName + options.extension` does not exists. 
+                            // try use `.mustache` extension to load `partial` file.
                             if ( partial === null ) {
                                 partialPath = path.resolve(templateDir, partialName + ".mustache");
                                 partial = fs.readFileSync(partialPath, 'utf8');
@@ -122,8 +124,10 @@ module.exports = function (view, options, partials) {
                         'error',
                         new gutil.PluginError(
                             'gulp-mustache',
-                            // use `ex.message` property instead of `partialPath`, because `this.emit()` seems not a sync method.
-                            // also the `ex.message` property provide more details about error information.
+                            // use `ex.message` property instead of `partialPath`, 
+                            // because `this.emit()` seems not a sync method.
+                            // also the `ex.message` property provide more details 
+                            // about error information.
                             'Unable to load partial file: ' + ex.message/*partialPath*/
                         )
                      );

--- a/index.js
+++ b/index.js
@@ -100,7 +100,10 @@ module.exports = function (view, options, partials) {
                             //   if `options.extension` equals ".html": 
                             //   `{{> ./path/to/partial }}` => `{{> ./path/to/partial.html }}`
                             if ( typeof options.extension == "string" ) {
-                                partialPath = path.resolve(templateDir, partialName + options.extension);
+                                partialPath = path.resolve(
+                                    templateDir, 
+                                    partialName + options.extension
+                                );
                                 
                                 if ( fs.existsSync(partialPath) ) {
                                     partial = fs.readFileSync(partialPath, 'utf8');

--- a/index.js
+++ b/index.js
@@ -71,16 +71,60 @@ module.exports = function (view, options, partials) {
 
             if (!partials[partialName]) {
                 try {
-                    var partialPath = path.resolve(templateDir, partialName + '.mustache');
-                    var partial = fs.readFileSync(partialPath, 'utf8');
+                    var partialPath = null;
+                    var partial = null;
+
+                    // ignore `partial` with file extension. 
+                    // e.g. 
+                    //   1, `{{> ./path/to/partial.html }}`
+                    //   2, `{{> ./path/to/partial. }}`
+                    if ( path.extname(partialName) != "" ) {
+                        partialPath = path.resolve(templateDir, partialName);
+                        partial = fs.readFileSync(partialPath, 'utf8');
+                    }
+
+                    else {
+                        // ignore `partial` file is exists without file extension.
+                        // e.g. 
+                        //   1, `{{> ./path/to/partial }}` is exists.
+                        //   2, `{{> ./path/to/.partial }}` is exists.
+                        partialPath = path.resolve(templateDir, partialName);
+                        
+                        if ( fs.existsSync(partialPath) ) {
+                            partial = fs.readFileSync(partialPath, 'utf8');
+                        }
+
+                        else {
+                            // or check if `partial + options.extension` is exists.
+                            // e.g. 
+                            //   if `options.extension` equals ".html": `{{> ./path/to/partial }}` => `{{> ./path/to/partial.html }}`
+                            if ( typeof options.extension == "string" ) {
+                                partialPath = path.resolve(templateDir, partialName + options.extension);
+                                
+                                if ( fs.existsSync(partialPath) ) {
+                                    partial = fs.readFileSync(partialPath, 'utf8');
+                                }
+                            }
+
+                            // when `options.extension` is not a string or `partialName + options.extension`
+                            // does not exists. try use `.mustache` extension to load `partial` file.
+                            if ( partial === null ) {
+                                partialPath = path.resolve(templateDir, partialName + ".mustache");
+                                partial = fs.readFileSync(partialPath, 'utf8');
+                            }
+                        }
+                    }
+
                     partials[partialName] = partial;
-                    loadPartials(partial, partialPath);
+                    loadPartials.call(this, partial, partialPath);
                 } catch (ex) {
                      this.emit(
                         'error',
                         new gutil.PluginError(
                             'gulp-mustache',
-                            'Unable to load partial file: ' + partialPath
+                            // use `ex.message` property instead of `partialPath`, because `this.emit()` seems not a sync method.
+                            // also the `ex.message` property provide more details about error information.
+                            'Unable to load partial file: ' + ex.message/*partialPath*/
                         )
                      );
                 }


### PR DESCRIPTION
Usage:
1, `{{> ./path/to/partial }}` will load `./path/to/partial` if exists. or load `./path/to/partial.mustache`.
2, if `options.extension` is provided, for example `options.extension = ".html"`, `{{> ./path/to/partial }}` will load `./path/to/partial` or `./path/to/partial.html` or `./path/to/partial.mustache`.
3, you can also provide extension  in your template file directly, for example: `{{> ./path/to/partial.template }}` will only check `./path/to/partial.template`.
