### PR TITLE
Add option to change mustache delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ The options object to configure the plugin.
 Type: `string`
 Default: the extension of the current file
 
+##### options.tags
+Type `Array`
+Default `undefined`
+
+Pass custom mustache delimiters. This must be an Array of strings where the first item is the opening tag and the second the closing tag.
+
+Example:
+
+```javascript
+['{{custom', 'custom}}']
+```
+
 #### partials
 Type: `hash`
 Default: `{ }`

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ module.exports = function (view, options, partials) {
 
     var viewError = null;
 
+    if (options.tags) {
+        mustache.tags = options.tags;
+    }
+
     // if view is string, interpret as path to json filename
     if (typeof view === 'string') {
         try {
@@ -63,7 +67,9 @@ module.exports = function (view, options, partials) {
     function loadPartials(template, templatePath) {
         var templateDir = path.dirname(templatePath);
 
-        var partialRegexp = /{{>\s*(\S+)\s*}}/g;
+        var partialRegexp = new RegExp(
+            mustache.tags[0] + '>\\s*(\\S+)\\s*' + mustache.tags[1], 'g'
+        );
 
         var partialMatch;
         while (partialMatch = partialRegexp.exec(template)) {

--- a/test/fixtures/custom-tags.mustache
+++ b/test/fixtures/custom-tags.mustache
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{m title m}}</title>
+</head>
+<body>
+<h1>{{m title m}}</h1>
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -174,23 +174,28 @@ describe('gulp-mustache', function () {
         stream.end();
     });
 
-    // it('should throw error when syntax is incorrect', function (done) {
+    it('should allow the change of mustache delimiters', function (done) {
+        var expectedFile = makeExpectedFile('test/expected/output.html');
+        var srcFile = makeFixtureFile('test/fixtures/custom-tags.mustache');
+        var stream = mustache(
+            { title: 'gulp-mustache' },
+            { tags: ['{{m', 'm}}'] }
+        );
 
-    //     var srcFile = new gutil.File({
-    //         path: 'test/fixtures/nok.mustache',
-    //         cwd: 'test/',
-    //         base: 'test/fixtures',
-    //         contents: fs.readFileSync('test/fixtures/nok.mustache')
-    //     });
+        stream.on('error', function (err) {
+            should.exist(err);
+            done(err);
+        });
 
-    //     var stream = mustache({ title: 'gulp-mustache' });
+        stream.on('data', function (newFile) {
 
-    //     stream.on('error', function (err) {
-    //         should.exist(err);
-    //         done();
-    //     });
+            should.exist(newFile);
+            should.exist(newFile.contents);
+            String(newFile.contents).should.equal(String(expectedFile.contents));
+            done();
+        });
 
-    //     stream.write(srcFile);
-    //     stream.end();
-    // });
+        stream.write(srcFile);
+        stream.end();
+    });
 });


### PR DESCRIPTION
This adds the option to pass a custom delimiter to mustache.

Example:

```javascript
gulpMustache({}, { tags: ['{{custom', 'custom}}'] });
```

This also fixes the `loadPartials()` regular expression that had the default mustache delimiters hardcoded.

Fixes #16