### PR TITLE
Emit mustache exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,17 @@ module.exports = function (view, options, partials) {
             );
         }
 
-        file.contents = new Buffer(mustache.render(template, file.data || view, partials));
+        try {
+            file.contents = new Buffer(
+                mustache.render(template, file.data || view, partials)
+            );
+        } catch (e) {
+            this.emit(
+                'error',
+                new gutil.PluginError('gulp-mustache', e.message)
+            );
+        }
+
         if (typeof options.extension === 'string') {
             file.path = gutil.replaceExtension(file.path, options.extension);
         }

--- a/test/fixtures/nok.mustache
+++ b/test/fixtures/nok.mustache
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>{{ tit }}</title>
-</head>
-<body>
-<h1>{{ title }}</h1>
-</body>
-</html>
+<div>
+    {{#invalid-syntax}{{/invalid-syntax}}
+</div>

--- a/test/main.js
+++ b/test/main.js
@@ -106,6 +106,20 @@ describe('gulp-mustache', function () {
         stream.end();
     });
 
+    it('should emit mustache errors', function (done) {
+        var srcFile = makeFixtureFile('test/fixtures/nok.mustache');
+
+        var stream = mustache({ title: 'gulp-mustache' });
+
+        stream.on('error', function (err) {
+            should.exist(err);
+            done();
+        });
+
+        stream.write(srcFile);
+        stream.end();
+    });
+
     it('should produce correct html output using json file', function (done) {
         var srcFile = new gutil.File({
             path: 'test/fixtures/ok.mustache',


### PR DESCRIPTION
mustache.render exceptions were not being emmited from the stream, so
the method call is now wrapped with a try-catch.

Related with issue #27