### PR TITLE
Add Mustache to package namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,3 +160,5 @@ module.exports = function (view, options, partials) {
         }
     }
 };
+
+module.exports.mustache = mustache;


### PR DESCRIPTION
Occasionally a user may want access to Mustache internals, such as by changing ```mustache.escape``` in order to alter the way that the underlying templating engine treats passed data.