### PR TITLE
Fix for custom mustache tags without escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var gutil = require('gulp-util');
 var mustache = require('mustache');
 var fs = require('fs');
 var path = require('path');
+var escapeRegex = require('escape-string-regexp');
 
 module.exports = function (view, options, partials) {
     options = options || {};
@@ -78,7 +79,7 @@ module.exports = function (view, options, partials) {
         var templateDir = path.dirname(templatePath);
 
         var partialRegexp = new RegExp(
-            mustache.tags[0] + '>\\s*(\\S+)\\s*' + mustache.tags[1], 'g'
+            escapeRegex(mustache.tags[0]) + '>\\s*(\\S+)\\s*' + escapeRegex(mustache.tags[1]), 'g'
         );
 
         var partialMatch;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "gulp-util": "^3.0.7",
     "mustache": "^2.2.1",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "escape-string-regexp": "^1.0.5"
   },
   "devDependencies": {
     "mocha": "^3.4.0",

--- a/test/fixtures/custom-tags-square-bracket.mustache
+++ b/test/fixtures/custom-tags-square-bracket.mustache
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>[[title]]</title>
+</head>
+<body>
+<h1>[[title]]</h1>
+</body>
+</html>

--- a/test/fixtures/okWithPartial-custom-tags-square-bracket.mustache
+++ b/test/fixtures/okWithPartial-custom-tags-square-bracket.mustache
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>[[ title ]]</title>
+</head>
+<body>
+<h1>[[ title ]]</h1>
+[[ > partial ]]
+</body>
+</html>
+

--- a/test/fixtures/partial-custom-tags-square-bracket.mustache
+++ b/test/fixtures/partial-custom-tags-square-bracket.mustache
@@ -1,0 +1,2 @@
+<p>I am a partial</p>
+<p>[[nested]]</p>

--- a/test/main.js
+++ b/test/main.js
@@ -212,4 +212,59 @@ describe('gulp-mustache', function () {
         stream.write(srcFile);
         stream.end();
     });
+
+    it('should allow the change of mustache delimiters without regex escaping', function (done) {
+        var expectedFile = makeExpectedFile('test/expected/output.html');
+        var srcFile = makeFixtureFile('test/fixtures/custom-tags-square-bracket.mustache');
+        var stream = mustache(
+            { title: 'gulp-mustache' },
+            { tags: ['[[', ']]'] }
+        );
+
+        stream.on('error', function (err) {
+            should.exist(err);
+            done(err);
+        });
+
+        stream.on('data', function (newFile) {
+
+            should.exist(newFile);
+            should.exist(newFile.contents);
+            String(newFile.contents).should.equal(String(expectedFile.contents));
+            done();
+        });
+
+        stream.write(srcFile);
+        stream.end();
+    });
+
+
+    it('should produce correct html output when rendering included partials and custom mustache delimiters without regex escaping', function (done) {
+
+        var expectedFile = makeExpectedFile('test/expected/outputWithPartial.html');
+        var srcFile = makeFixtureFile('test/fixtures/okWithPartial-custom-tags-square-bracket.mustache');
+        var partialFile = makeFixtureFile('test/fixtures/partial-custom-tags-square-bracket.mustache');
+
+        var stream = mustache(
+            { title: 'gulp-mustache', nested: 'I am nested' },
+            { tags: ['[[', ']]'] },
+            { partial: partialFile.contents.toString() }
+        );
+
+        stream.on('error', function (err) {
+            should.exist(err);
+            done(err);
+        });
+
+        stream.on('data', function (newFile) {
+
+            should.exist(newFile);
+            should.exist(newFile.contents);
+            String(newFile.contents).should.equal(String(expectedFile.contents));
+            done();
+        });
+
+        stream.write(srcFile);
+        stream.end();
+    });
 });


### PR DESCRIPTION
Since there is also not a proper exception in case the mustache tag was incorrectly escaped it is not intuitive to escape a custom tag unless you have a look at the frameworks source code.

Added escaping for these tags.