### PR TITLE
refactor: remove gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error')
+var replaceExtension = require('replace-ext')
 var mustache = require('mustache');
 var fs = require('fs');
 var path = require('path');
@@ -35,14 +36,14 @@ module.exports = function (view, options, partials) {
         if (file.isStream()) {
             this.emit(
                 'error',
-                new gutil.PluginError('gulp-mustache', 'Streaming not supported')
+                new PluginError('gulp-mustache', 'Streaming not supported')
             );
         }
 
         if (viewError) {
             this.emit(
                 'error',
-                new gutil.PluginError('gulp-mustache', viewError.toString())
+                new PluginError('gulp-mustache', viewError.toString())
             );
         }
 
@@ -52,7 +53,7 @@ module.exports = function (view, options, partials) {
         } catch (e) {
             this.emit(
                 'error',
-                new gutil.PluginError('gulp-mustache', e.message)
+                new PluginError('gulp-mustache', e.message)
             );
         }
 
@@ -63,12 +64,12 @@ module.exports = function (view, options, partials) {
         } catch (e) {
             this.emit(
                 'error',
-                new gutil.PluginError('gulp-mustache', e.message)
+                new PluginError('gulp-mustache', e.message)
             );
         }
 
         if (typeof options.extension === 'string') {
-            file.path = gutil.replaceExtension(file.path, options.extension);
+            file.path = replaceExtension(file.path, options.extension);
         }
         this.push(file);
         cb();
@@ -147,7 +148,7 @@ module.exports = function (view, options, partials) {
                 } catch (ex) {
                      this.emit(
                         'error',
-                        new gutil.PluginError(
+                        new PluginError(
                             'gulp-mustache',
                             // use `ex.message` property instead of `partialPath`,
                             // because `this.emit()` seems not a sync method.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,22 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
       "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
@@ -12,9 +28,38 @@
       "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
       "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
     },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "arr-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+      "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+      "requires": {
+        "arr-flatten": "1.1.0",
+        "array-slice": "0.2.3"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+    },
     "array-differ": {
       "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
     },
     "array-uniq": {
       "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
@@ -74,12 +119,47 @@
       }
     },
     "clone": {
-      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
     },
     "clone-stats": {
-      "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "process-nextick-args": "1.0.7",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -117,6 +197,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "extend-shallow": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+      "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+      "requires": {
+        "kind-of": "1.1.0"
+      }
     },
     "fancy-log": {
       "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
@@ -175,15 +263,40 @@
         "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
         "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "replace-ext": "0.0.1",
         "through2": "2.0.3",
-        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+        "vinyl": "0.5.3"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "dateformat": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
           "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "requires": {
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
         }
       }
     },
@@ -264,6 +377,11 @@
     "isarray": {
       "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "kind-of": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "load-json-file": {
       "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -591,6 +709,18 @@
         "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
       }
     },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      }
+    },
     "process-nextick-args": {
       "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
       "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
@@ -630,6 +760,12 @@
         "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
       }
     },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
     "repeating": {
       "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
       "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
@@ -638,8 +774,9 @@
       }
     },
     "replace-ext": {
-      "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -826,12 +963,17 @@
       }
     },
     "vinyl": {
-      "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+      "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+      "dev": true,
       "requires": {
-        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+        "clone": "2.1.1",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.0.0",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
-    "gulp-util": "^3.0.8",
     "mustache": "^2.3.0",
+    "plugin-error": "^0.1.2",
+    "replace-ext": "^1.0.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {
     "mocha": "^4.0.0",
-    "should": "^13.0.0"
+    "should": "^13.0.0",
+    "vinyl": "^2.1.0"
   },
   "engines": {
     "npm": ">=1.2.10"

--- a/test/main.js
+++ b/test/main.js
@@ -1,16 +1,17 @@
 /*global describe, it*/
 'use strict';
 
-var fs = require('fs'),
-should = require('should'),
-path = require('path');
 require('mocha');
 
-var gutil = require('gulp-util'),
-mustache = require('../');
+var fs = require('fs');
+var should = require('should');
+var path = require('path');
+var Vinyl = require('vinyl');
+
+var mustache = require('../');
 
 var makeFile = function (path, base) {
-    return new gutil.File({
+    return new Vinyl({
         path: path,
         cwd: 'test/',
         base: base,
@@ -121,7 +122,7 @@ describe('gulp-mustache', function () {
     });
 
     it('should produce correct html output using json file', function (done) {
-        var srcFile = new gutil.File({
+        var srcFile = new Vinyl({
             path: 'test/fixtures/ok.mustache',
             cwd: 'test/',
             base: 'test/fixtures',
@@ -150,7 +151,7 @@ describe('gulp-mustache', function () {
     });
 
     it('should detect malformed json and emit error', function (done) {
-        var srcFile = new gutil.File({
+        var srcFile = new Vinyl({
             path: 'test/fixtures/ok.mustache',
             cwd: 'test/',
             base: 'test/fixtures',
@@ -169,7 +170,7 @@ describe('gulp-mustache', function () {
     });
 
     it('should emit partial not found error when partial is missing', function (done) {
-        var srcFile = new gutil.File({
+        var srcFile = new Vinyl({
             path: 'test/fixtures/missing-partial.mustache',
             cwd: 'test/',
             base: 'test/fixtures',


### PR DESCRIPTION
Since gulp-util is now deprecated and will be removed in Gulp 4, this PR removes gulp-util and replaces it's utils with alternative packages.