### PR TITLE
fix: switch Buffer instantiaton for Buffer.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function (view, options, partials) {
         }
 
         try {
-            file.contents = new Buffer(
+            file.contents = Buffer.from(
                 mustache.render(template, file.data || view, partials)
             );
         } catch (e) {


### PR DESCRIPTION
This avoids the deprecation warnings on Node 10.